### PR TITLE
Updated service object

### DIFF
--- a/app/controllers/api/v1/lifts_controller.rb
+++ b/app/controllers/api/v1/lifts_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::LiftsController < ApplicationController
   skip_before_action :verify_authenticity_token
-  # before_action :authenticate_user
+  before_action :authenticate_user
 
   def index
     lifts = current_user.lifts
@@ -19,7 +19,7 @@ class Api::V1::LiftsController < ApplicationController
       ProgressionBuilder.new(new_weight_array, current_user).build_workouts
     end
     lifts = current_user.lifts.all
-    render json:lifts
+    render json: lifts
   end
 
   def update

--- a/app/services/progression_builder.rb
+++ b/app/services/progression_builder.rb
@@ -17,7 +17,7 @@ class ProgressionBuilder
       when 3
         lift = "Overhead Press"
       end
-      Lift.create(name: lift, initial_1rm: weight, user_id: @current_user.id)
+      Lift.create(name: lift, initial_1rm: weight.to_i, user_id: @current_user.id)
     end
     build_workouts()
   end
@@ -39,7 +39,14 @@ class ProgressionBuilder
   end
 
   def build_sets
-    all_workouts = Workout.all
+    all_lifts = @current_user.lifts
+    all_workouts = []
+    all_lifts.each do |lift|
+      lift.workouts.each do |workout|
+        all_workouts << workout
+      end
+    end
+    binding.pry
     all_workouts.each do |workout|
       case workout.format
       when "3x5"


### PR DESCRIPTION
-Service object logic now only builds sets associated to the user (previously it tried to build sets for all workouts and didn't have access to other user's data, hence returning the pesky 422